### PR TITLE
Added LevelOfParallelism Attribute

### DIFF
--- a/NUnit-BrowserStack/Properties/AssemblyInfo.cs
+++ b/NUnit-BrowserStack/Properties/AssemblyInfo.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 [assembly: AssemblyCopyright("Copyright ©  2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+// For more details on LevelOfParallelism Attribute review NUnit documentation- https://github.com/nunit/docs/wiki/LevelOfParallelism-Attribute
 [assembly: LevelOfParallelism(2)]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/NUnit-BrowserStack/Properties/AssemblyInfo.cs
+++ b/NUnit-BrowserStack/Properties/AssemblyInfo.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
+using NUnit.Framework;
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("NUnit-BrowserStack")]
@@ -13,9 +13,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: LevelOfParallelism(2)]
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -25,11 +25,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
## Added LevelOfParallelism Attribute

Changes on -

Line No 4 and Line No 16

Description -

This is an assembly-level attribute, which may be used to specify the level of parallelism, that is, the maximum number of worker threads executing tests in the assembly. It may be overridden using a command-line option in the console runner.

This attribute is optional. If it is not specified, NUnit uses the processor count or 2, whichever is greater. For example, on a four processor machine the default value is 4.

Example
The following code, which might be placed in AssemblyInfo.cs, sets the level of parallelism to 3:

  [assembly:LevelOfParallelism(3)]



